### PR TITLE
Pinned old ffmpeg version (3.4) in py36 ci env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   fast_finish: true
   include:
   - env: CONDA_ENV=py36
-  - env: CONDA_ENV=py36
+  - env: CONDA_ENV=py37
 
 before_install:
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -10,7 +10,7 @@ dependencies:
   - future
   - matplotlib
   - cartopy
-  - ffmpeg
+  - ffmpeg=3.4
   - pip:
     - codecov
     - pytest-cov


### PR DESCRIPTION
I pineed the ffmpeg version in the py36 environment to an older version (3.4) to ensure tests are run in both.