### PR TITLE
Refactor complete. Tests passing locally.

### DIFF
--- a/First_Steps.ipynb
+++ b/First_Steps.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -539,6 +539,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   },
   "varInspector": {
    "cols": {

--- a/xmovie/presets.py
+++ b/xmovie/presets.py
@@ -10,26 +10,13 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
 
-# Data treatment
-def _get_plot_defaults(da):
-    if isinstance(da, xr.DataArray):
-        data = da
-    else:
-        raise RuntimeError("input of type (%s) not supported" % type(da))
-    defaults = dict([])
-    defaults["vmin"] = data.min().data
-    defaults["vmax"] = data.max().data
-    defaults["cbar_kwargs"] = dict(extend="neither")
-    return defaults
-
-
-def check_input(da, fieldname):
+def _check_input(da, fieldname):
     # pick the data_var to plot
     if isinstance(da, xr.Dataset):
         if fieldname is None:
             fieldname = list(da.data_vars)[0]
             warnings.warn(
-                "No plot_variable supplied. Defaults to `%s`" % fieldname, UserWarning
+                "No `fieldname` supplied. Defaults to `%s`" % fieldname, UserWarning
             )
         data = da[fieldname]
     elif isinstance(da, xr.DataArray):
@@ -51,7 +38,7 @@ def _core_plot(ax, data, plotmethod=None, **kwargs):
     if plotmethod == "contour":
         kwargs.pop("cbar_kwargs", None)
 
-    # I am probably recoding something from matplotlib...is ther a way to get
+    # I am probably recoding something from matplotlib...is there a way to get
     # the plot.something functionslity with a keyword?
     # For now do it the hard way
     if plotmethod is None:
@@ -78,17 +65,9 @@ def _core_plot(ax, data, plotmethod=None, **kwargs):
 
 
 def _base_plot(ax, base_data, timestamp, plotmethod=None, **kwargs):
-    # core plot call with updated defaults
-
-    # set sensible defaults for each plotmethod
-    plt_kwargs = _get_plot_defaults(base_data)
-
-    # update with supplied kwargs and map_style_kwargs
-    plt_kwargs.update(kwargs)
-
     # need to convert time to input variable
     data = base_data.isel(time=timestamp)
-    p = _core_plot(ax, data, plotmethod=plotmethod, **plt_kwargs)
+    p = _core_plot(ax, data, plotmethod=plotmethod, **kwargs)
     return p
 
 
@@ -240,7 +219,7 @@ def basic(
 ):
     # create axis
     ax = fig.subplots(subplot_kw=subplot_kw)
-    data = check_input(da, plot_variable)
+    data = _check_input(da, plot_variable)
     pp = _base_plot(ax, data, timestamp, plotmethod=plotmethod, **kwargs)
     return ax, pp
 
@@ -284,9 +263,9 @@ def rotating_globe(
     map_style_kwargs = dict(transform=ccrs.PlateCarree())
     kwargs.update(map_style_kwargs)
 
-    # create axis
+    # create axis (TODO:this should be handled by the basic preset )
     ax = fig.subplots(subplot_kw=subplot_kw)
-    data = check_input(da, plot_variable)
+    data = _check_input(da, plot_variable)
     pp = _base_plot(ax, data, timestamp, plotmethod=plotmethod, **kwargs)
 
     _set_style(fig, ax, pp, style=style)

--- a/xmovie/test/test_presets.py
+++ b/xmovie/test/test_presets.py
@@ -2,23 +2,13 @@ import xarray as xr
 import numpy as np
 import pytest
 from xmovie.presets import (
-    _get_plot_defaults,
-    check_input,
+    _check_input,
     _core_plot,
     _smooth_boundary_NearsidePerspective,
 )
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
-
-
-def test_get_plot_defaults():
-    # create dummy array
-    da = xr.DataArray(np.arange(20), dims=["x"])
-    d = _get_plot_defaults(da)
-    assert d["vmax"] == 19
-    assert d["vmin"] == 0
-    assert d["cbar_kwargs"] == dict(extend="neither")
 
 
 def test_check_input():
@@ -29,10 +19,10 @@ def test_check_input():
             "b": xr.DataArray(np.arange(4), dims=["y"]),
         }
     )
-    xr.testing.assert_identical(ds["a"], check_input(ds, None))
-    xr.testing.assert_identical(ds["b"], check_input(ds, "b"))
-    xr.testing.assert_identical(ds["a"], check_input(ds["a"], None))
-    xr.testing.assert_identical(ds["a"], check_input(ds["a"], "b"))
+    xr.testing.assert_identical(ds["a"], _check_input(ds, None))
+    xr.testing.assert_identical(ds["b"], _check_input(ds, "b"))
+    xr.testing.assert_identical(ds["a"], _check_input(ds["a"], None))
+    xr.testing.assert_identical(ds["a"], _check_input(ds["a"], "b"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The function determining the colorlimits was executed for every frame, serverly limiting performance. 
It is now executed when the `Movie` object is created, and can be deactivated with `input_check=False`. This is necessary when passing datasets (instead of dataarrays), e.g. for custom plot functions like in the examples.
