### PR TITLE
Improve `__init__`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+xmovie/_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/xmovie/__init__.py
+++ b/xmovie/__init__.py
@@ -1,3 +1,12 @@
-__version__ = "0.1.0"
 from .core import Movie
 from .presets import rotating_globe
+
+
+try:
+    from ._version import __version__
+
+except ModuleNotFoundError:
+    __version__ == "999"
+
+
+__all__ = ("Movie", "rotating_globe")

--- a/xmovie/__init__.py
+++ b/xmovie/__init__.py
@@ -6,7 +6,7 @@ try:
     from ._version import __version__
 
 except ModuleNotFoundError:
-    __version__ == "999"
+    __version__ == "unknown"
 
 
 __all__ = ("Movie", "rotating_globe")


### PR DESCRIPTION
I had done `python -m pydoc xmovie` and saw that the version there didn't match what it should be and the top level names weren't listed. Fixed by importing `__version__` and adding `__all__`.