### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
   core-deps-dev:
     name: Build (core-dependencies)
     if: github.repository == 'jbusecke/xmovie'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
Fix the CI workflow so that it can pass.

Current error message, causing failure even though the main job passes, e.g. [here](https://github.com/jbusecke/xmovie/actions/runs/1381255482):
```
Error when evaluating 'runs-on' for job 'core-deps-dev'. .github/workflows/ci.yaml (Line: 62, Col: 14): Unexpected value ''
```

Changes:
* Give `runs-on` a value in job `core-deps-dev`