### PR TITLE
Dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           channels: conda-forge
           mamba-version: '*'
           channel-priority: strict
-          activate-environment: test_env_xmovie # Defined in ci/environment*.yml
+          activate-environment: xmovie-test # Defined in ci/environment*.yml
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
@@ -86,9 +86,9 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-core-deps.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: test_env_xmovie # Defined in ci/environment*.yml
+          activate-environment: xmovie-test-core # Defined in ci/environment*.yml
           auto-update-conda: false
-          python-version: 3.9
+          python-version: '3.9'
           environment-file: ci/environment-core-deps.yml
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Set up conda environment

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ var/
 .installed.cfg
 *.egg
 
+# Virtual environment
+venv*/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,8 @@
 version: 2
 
-conda:
-  environment: ci/environment-docs.yml
+python:
+  install:
+    - requirements: docs/requirements-rtd.txt
 
 sphinx:
   configuration: docs/conf.py

--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -11,7 +11,7 @@ dependencies:
   - numpy
   - xarray
   #
-  # - ffmpeg
+  - ffmpeg
   #
   # Tests
   - opencv

--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -7,7 +7,6 @@ dependencies:
   - python
   #
   # xmovie core
-  - dask-core
   - matplotlib
   - numpy
   - xarray

--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -1,17 +1,20 @@
-name: test_env_xmovie
+name: xmovie-test-core
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
-  - xarray
+  - python
+  #
+  # xmovie core
   - dask
-  - scipy
-  - numpy
-  - pytest
-  - future
   - matplotlib
-  - cartopy
-  - pykdtree
+  - numpy
+  - xarray
+  #
+  # - ffmpeg
+  #
+  # Tests
   - opencv
-  - pip:
-    - codecov
-    - pytest-cov
+  - pillow
+  - pytest
+  - pytest-cov

--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -1,3 +1,4 @@
+# Conda environment for testing xmovie in CI
 name: xmovie-test-core
 channels:
   - conda-forge
@@ -6,7 +7,7 @@ dependencies:
   - python
   #
   # xmovie core
-  - dask
+  - dask-core
   - matplotlib
   - numpy
   - xarray

--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -4,26 +4,32 @@ channels:
   - nodefaults
 dependencies:
   - python=3.8
-  # Core
-  - xarray
+  - pip
+  #
+  # xmovie core
   - matplotlib
-  - cartopy
+  - numpy
+  - xarray
+  #
   - ffmpeg
+  #
   # Optional
-  - tqdm
+  - cartopy
   - dask-core
+  - tqdm
+  #
   # Examples
-  - pooch
-  - jupyterlab
   - ipywidgets
+  - jupyterlab
+  - pooch
+  #
   # Docs
+  - nbsphinx
   - sphinx>=4.0
   - sphinx-autobuild
   - sphinx-book-theme
-  - nbsphinx
   - sphinx-copybutton
   #
-  - pip
   - pip:
     - sphinx-prompt
     - '-e ../'  # xmovie

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,3 +1,4 @@
+# Conda environment for testing xmovie in CI
 name: xmovie-test
 channels:
   - conda-forge
@@ -6,7 +7,7 @@ dependencies:
   - python
   #
   # xmovie core
-  - dask
+  - dask-core
   - matplotlib
   - numpy
   - xarray

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -15,10 +15,10 @@ dependencies:
   #
   # Extras
   - cartopy
-  - cftime
-  - nc-time-axis
-  - scipy
-  - tqdm
+  # - cftime
+  # - nc-time-axis
+  # - scipy
+  # - tqdm
   #
   # Test
   - opencv

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - python
   #
   # xmovie core
-  - dask-core
   - matplotlib
   - numpy
   - xarray
@@ -17,6 +16,7 @@ dependencies:
   # Extras
   - cartopy
   # - cftime
+  - dask-core
   # - nc-time-axis
   # - scipy
   # - tqdm

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,19 +1,27 @@
-name: test_env_xmovie
+name: xmovie-test
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
-  - xarray
+  - python
+  #
+  # xmovie core
   - dask
-  - scipy
-  - numpy
-  - pytest
-  - future
   - matplotlib
-  - cartopy
-  - pykdtree
+  - numpy
+  - xarray
+  #
   - ffmpeg
+  #
+  # Extras
+  - cartopy
+  - cftime
+  - nc-time-axis
+  - scipy
   - tqdm
+  #
+  # Test
   - opencv
-  - pip:
-    - codecov
-    - pytest-cov
+  - pillow
+  - pytest
+  - pytest-cov

--- a/docs/environment-docs-dev.yml
+++ b/docs/environment-docs-dev.yml
@@ -1,3 +1,5 @@
+# Conda environment for docs development,
+# including running the example notebooks
 name: xmovie-docs
 channels:
   - conda-forge
@@ -18,7 +20,7 @@ dependencies:
   - dask-core
   - tqdm
   #
-  # Examples
+  # Example notebooks
   - ipywidgets
   - jupyterlab
   - pooch
@@ -32,4 +34,4 @@ dependencies:
   #
   - pip:
     - sphinx-prompt
-    - '-e ../'  # xmovie
+    - '-e ../'  # xmovie itself

--- a/docs/environment-docs-dev.yml
+++ b/docs/environment-docs-dev.yml
@@ -13,8 +13,6 @@ dependencies:
   - numpy
   - xarray
   #
-  - ffmpeg
-  #
   # Optional
   - cartopy
   - dask-core

--- a/docs/examples/quickstart.ipynb
+++ b/docs/examples/quickstart.ipynb
@@ -249,15 +249,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![movie_fast.gif](movie_fast.gif)\n",
-    "![movie_slow.gif](movie_slow.gif)"
+    "![fast GIF](movie_fast.gif)\n",
+    "![slow GIF](movie_slow.gif)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](movie_combo.gif)"
+    "![combo GIF](movie_combo.gif)"
    ]
   },
   {
@@ -297,7 +297,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](lon_movie.gif)"
+    "![lon dim GIF](lon_movie.gif)"
    ]
   },
   {
@@ -355,7 +355,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![movie_rotating.gif](movie_rotating.gif)"
+    "![rotating GIF](movie_rotating.gif)"
    ]
   },
   {
@@ -395,7 +395,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](movie_rotating_dark.gif)"
+    "![rotating dark GIF](movie_rotating_dark.gif)"
    ]
   },
   {
@@ -440,8 +440,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](movie_cont.gif)\n",
-    "![](movie_contf.gif)"
+    "![rotating contour GIF](movie_cont.gif)\n",
+    "![rotating contourf GIF](movie_contf.gif)"
    ]
   },
   {
@@ -509,7 +509,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](movie_rasm.gif)"
+    "![RASM GIF](movie_rasm.gif)"
    ]
   },
   {
@@ -666,7 +666,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](movie_custom.gif)"
+    "![custom plotfunc movie](movie_custom.gif)"
    ]
   }
  ],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,10 +55,17 @@ The main aims of this module are:
 Installation
 ------------
 
+.. important::
+
+   `ffmpeg`_ is required in order to create the movies from the saved PNG frames.
+   See `their installation instructions <https://ffmpeg.org/download.html>`_.
+   ``ffmpeg``\'s location must be in the OS search path (``PATH``) for movie creation to work.
+
 .. note::
 
    For now, ``dask(-core)`` and ``cartopy`` are included with ``xmovie``,
    but they may be optional dependencies in the future.
+
 
 Conda
 ~~~~~
@@ -68,6 +75,15 @@ The easiest way to install ``xmovie`` is via ``conda``:
 .. prompt:: bash
 
    conda install -c conda-forge xmovie
+
+
+.. note::
+
+   conda-forge includes a recipe for ffmpeg. To install both:
+
+   .. prompt:: bash
+
+      conda install -c conda-forge xmovie ffmpeg
 
 Pip
 ~~~
@@ -103,3 +119,5 @@ If you want to install the latest version from GitHub, simply run
 .. _xarray: https://xarray.pydata.org
 .. _Matplotlib: https://matplotlib.org
 .. _Dask: https://dask.org
+.. _ffmpeg: https://ffmpeg.org/
+.. _ffmpeg-download: https://ffmpeg.org/download.html

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,0 +1,9 @@
+# pip requirements to build the docs on RTD
+# (example notebook deps are not needed since we do not run them in the docs build)
+../
+ipython
+nbsphinx
+sphinx ~= 4.0
+sphinx-book-theme
+sphinx-copybutton
+sphinx-prompt

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,6 +3,14 @@ What's New
 v0.3.0 (unreleased)
 -------------------
 
+Packaging
+~~~~~~~~~
+- ``cartopy`` (used in the :func:`~xmovie.rotating_globe` preset)
+  and ``dask`` (used for parallel frame saving)
+  are now optional extras instead of package requirements
+  (:pull:`XX`).
+  By `zmoon <https://github.com/zmoon>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 - Sphinx docs build, published to Read the Docs (:pull:`67`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ exclude = xmovie/_version.py
 name = xmovie
 description = Simply create beautiful movies from xarray objects
 author = xmovie developers
-url=https://github.com/jbusecke/xmovie
+author_email = jbusecke@princeton.edu
+url = https://github.com/jbusecke/xmovie
 license = MIT
 license_file = LICENSE
 
@@ -46,21 +47,22 @@ classifiers =
     # Dont change this one
     License :: OSI Approved :: MIT License
 
-## Add your email here
-author_email = jbusecke@princeton.edu
 
-
-### make sure to fill in your dependencies!
 [options]
 install_requires =
     numpy
     xarray
     dask
-    cartopy
 setup_requires=
     setuptools_scm
 python_requires = >=3.6
-################ Up until here
+
+[options.extras_require]
+maps =
+    cartopy
+cftime =
+    cftime
+    nc-time-axis
 
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,9 +50,10 @@ classifiers =
 
 [options]
 install_requires =
+    dask
+    matplotlib
     numpy
     xarray
-    dask
 setup_requires=
     setuptools_scm
 python_requires = >=3.6
@@ -63,6 +64,12 @@ maps =
 cftime =
     cftime
     nc-time-axis
+prog =
+    tqdm
+all =
+    %(maps)s
+    %(cftime)s
+    %(prog)s
 
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,52 @@
+[metadata]
+name = xmovie
+description = Simply create beautiful movies from xarray objects
+author = xmovie developers
+author_email = jbusecke@princeton.edu
+url = https://github.com/jbusecke/xmovie
+license = MIT
+license_file = LICENSE
+classifiers =
+    Development Status :: 4 - Beta
+    Topic :: Scientific/Engineering
+    Intended Audience :: Science/Research
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    License :: OSI Approved :: MIT License
+
+[options]
+install_requires =
+    matplotlib
+    numpy
+    xarray
+setup_requires =
+    setuptools_scm
+python_requires = >=3.6
+include_package_data = True
+zip_safe = False
+packages = find:
+
+[options.extras_require]
+maps =
+    cartopy
+parallel =
+    dask
+cftime =
+    cftime
+    nc-time-axis
+progress = tqdm
+all =
+    %(maps)s
+    %(parallel)s
+    %(cftime)s
+    %(progress)s
+
+
 [sdist]
 formats = gztar
 
@@ -19,60 +68,3 @@ max-line-length = 105
 select = C,E,F,W,B,B950
 ignore = E203, E501, W503
 exclude = xmovie/_version.py
-
-
-[metadata]
-name = xmovie
-description = Simply create beautiful movies from xarray objects
-author = xmovie developers
-author_email = jbusecke@princeton.edu
-url = https://github.com/jbusecke/xmovie
-license = MIT
-license_file = LICENSE
-
-## These need to be filled in by the author!
-# For details see: https://pypi.org/classifiers/
-
-classifiers =
-    Development Status :: 4 - Beta
-    Topic :: Scientific/Engineering
-    Intended Audience :: Science/Research
-    Operating System :: OS Independent
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    # Dont change this one
-    License :: OSI Approved :: MIT License
-
-
-[options]
-install_requires =
-    matplotlib
-    numpy
-    xarray
-setup_requires=
-    setuptools_scm
-python_requires = >=3.6
-
-[options.extras_require]
-maps =
-    cartopy
-parallel =
-    dask
-cftime =
-    cftime
-    nc-time-axis
-progress =
-    tqdm
-all =
-    %(maps)s
-    %(parallel)s
-    %(cftime)s
-    %(progress)s
-
-include_package_data = True
-zip_safe = False
-packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ classifiers =
 
 [options]
 install_requires =
-    dask
     matplotlib
     numpy
     xarray
@@ -61,15 +60,18 @@ python_requires = >=3.6
 [options.extras_require]
 maps =
     cartopy
+parallel =
+    dask
 cftime =
     cftime
     nc-time-axis
-prog =
+progress =
     tqdm
 all =
     %(maps)s
+    %(parallel)s
     %(cftime)s
-    %(prog)s
+    %(progress)s
 
 include_package_data = True
 zip_safe = False

--- a/xmovie/core.py
+++ b/xmovie/core.py
@@ -1,17 +1,17 @@
-import matplotlib as mpl
-
-mpl.use("Agg")
-import re
-import os
-import sys
-import glob
-import warnings
 import gc
+import glob
+import os
+import re
+import sys
+import warnings
+from subprocess import Popen, PIPE, STDOUT
+
+import dask.array as dsa
+import matplotlib as mpl
+import matplotlib.pyplot as plt
 import xarray as xr
 
 from .presets import _check_input, basic
-from subprocess import Popen, PIPE, STDOUT
-import matplotlib.pyplot as plt
 
 try:
     from tqdm.auto import tqdm
@@ -19,15 +19,13 @@ try:
     tqdm_avail = True
 except:
     warnings.warn(
-        "Optional dependency `tqdm` not found. This will make progressbars a lot nicer. \
-    Install with `conda install -c conda-forge tqdm`"
+        "Optional dependency `tqdm` not found. "
+        "This will make progressbars a lot nicer. "
+        "Install with `conda install -c conda-forge tqdm`"
     )
     tqdm_avail = False
 
-# import xarray as xr
-# import dask.bag as db
-import dask.array as dsa
-
+mpl.use("Agg")
 
 # is it a good idea to set these here?
 # Needs to be dependent on dpi and videosize

--- a/xmovie/presets.py
+++ b/xmovie/presets.py
@@ -5,11 +5,6 @@ import matplotlib.ticker as mticker
 import numpy as np
 import xarray as xr
 
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
-import shapely.geometry as sgeom
-from cartopy.mpl import geoaxes
-
 
 def _check_input(da, fieldname):
     # pick the data_var to plot
@@ -73,6 +68,9 @@ def _base_plot(ax, base_data, timestamp, framedim, plotmethod=None, **kwargs):
 
 # projections utilities and hacks
 def _smooth_boundary_NearsidePerspective(projection):
+    import cartopy.crs as ccrs
+    import shapely.geometry as sgeom
+
     # workaround for a smoother outer boundary
     # (https://github.com/SciTools/cartopy/issues/613)
     # Re-implement the cartopy code to figure out the boundary.
@@ -93,6 +91,9 @@ def _smooth_boundary_NearsidePerspective(projection):
 
 
 # def _smooth_boundary_globe(projection):
+#    import cartopy.crs as ccrs
+#    import shapely.geometry as sgeom
+#
 #     # workaround for a smoother outer boundary
 #     # (https://github.com/SciTools/cartopy/issues/613)
 #
@@ -137,10 +138,13 @@ def _style_dict(style=None):
 
 def _set_style(fig, ax, pp, style):
     "Sets the colorscheme for figure, axis and plot object (`pp`) according to style"
-    # check if ax is 'normal' or cartopy projection
-    is_geoax = False
-    if isinstance(ax, geoaxes.GeoAxesSubplot):
-        is_geoax = True
+    # Check if ax is 'normal' or cartopy projection
+    try:
+        from cartopy.mpl import geoaxes
+    except ImportError:
+        is_geoax = False
+    else:
+        is_geoax = isinstance(ax, geoaxes.GeoAxesSubplot)
 
     # parse styles
     style_dict = _style_dict(style)
@@ -190,6 +194,9 @@ def _set_style(fig, ax, pp, style):
 
 
 def _add_land(ax, style):
+    import cartopy.feature as cfeature
+    from cartopy.mpl import geoaxes
+
     if not isinstance(ax, geoaxes.GeoAxesSubplot):
         raise ValueError("Cannot add land on non-cartopy axes. Got ($s)" % type(ax))
     style_dict = _style_dict(style)
@@ -200,6 +207,9 @@ def _add_land(ax, style):
 
 
 def _add_coast(ax, style):
+    import cartopy.feature as cfeature
+    from cartopy.mpl import geoaxes
+    
     if not isinstance(ax, geoaxes.GeoAxesSubplot):
         raise ValueError("Cannot add land on non-cartopy axes. Got ($s)" % type(ax))
     style_dict = _style_dict(style)
@@ -285,6 +295,10 @@ def rotating_globe(
     **kwargs
         Passed on to the xarray plotting method.
     """
+    try:
+        import cartopy.crs as ccrs
+    except ImportError as e:
+        raise Exception("This preset requires `cartopy`") from e
 
     # rotate lon_rotations times throughout movie and start at lon_start
     lon = np.linspace(0, 360 * lon_rotations, len(da[framedim])) + lon_start

--- a/xmovie/presets.py
+++ b/xmovie/presets.py
@@ -1,13 +1,14 @@
 import warnings
-import numpy as np
-import xarray as xr
-from cartopy.mpl import geoaxes
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
 
-import shapely.geometry as sgeom
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
+import numpy as np
+import xarray as xr
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import shapely.geometry as sgeom
+from cartopy.mpl import geoaxes
 
 
 def _check_input(da, fieldname):

--- a/xmovie/test/test_core.py
+++ b/xmovie/test/test_core.py
@@ -1,3 +1,14 @@
+import os
+
+import cv2
+import dask.array as dsa
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
+from PIL import Image
+
 from xmovie.core import (
     _parse_plot_defaults,
     _check_plotfunc_output,
@@ -10,15 +21,13 @@ from xmovie.core import (
     Movie,
 )
 from xmovie.presets import basic, rotating_globe
-import pytest
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-from PIL import Image
-import numpy as np
-import xarray as xr
-import os
-import cv2
-import dask.array as dsa
+
+try:
+    import cartopy
+except ImportError:
+    cartopy_avail = False
+else:
+    cartopy_avail = True
 
 
 def test_parse_plot_defaults():
@@ -232,6 +241,8 @@ def test_Movie(plotfunc, framedim, frame_pattern, dpi, pixelheight, pixelwidth):
         pixelheight=pixelheight,
         dpi=dpi,
     )
+    if plotfunc is rotating_globe and not cartopy_avail:
+        pytest.skip("`rotating_globe` requires `cartopy`")
 
     # if not time, hide it to test changing default
     if framedim != "time":

--- a/xmovie/test/test_presets.py
+++ b/xmovie/test/test_presets.py
@@ -8,7 +8,15 @@ from xmovie.presets import (
 )
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-import cartopy.crs as ccrs
+
+try:
+    import cartopy.crs as ccrs
+except ImportError:
+    cartopy_avail = False
+else:
+    cartopy_avail = True
+
+
 
 
 def test_check_input():
@@ -42,6 +50,7 @@ def test_core_plot(plotmethod, expected_type, filled):
         assert pp.filled == filled
 
 
+@pytest.mark.skipif(not cartopy_avail, reason="Requires cartopy")
 @pytest.mark.parametrize("lon", [-700, -300, 1, 300, 700])
 @pytest.mark.parametrize("lat", [-200, -90, 0, 90, 180])
 @pytest.mark.parametrize("sat_height", [35785831, 45785831])

--- a/xmovie/test/test_presets.py
+++ b/xmovie/test/test_presets.py
@@ -17,8 +17,6 @@ else:
     cartopy_avail = True
 
 
-
-
 def test_check_input():
     # this should be done with a more sophisticated example
     ds = xr.Dataset(


### PR DESCRIPTION
Closes #71 and also should speed up the RTD build

* `cartopy` and `dask.array` now optional
* user-facing methods that need them raise exception if they are not importable
* [ ] create exception type (`MissingDependency`)? to raise and change the tests to xfail on this instead of skip
* notes about ffmpeg requirement in the docs
* minimal pip requirements for RTD