### PR TITLE
Stop supporting python 3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
         
     
     steps:

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,6 +9,11 @@ Documentation
   By `zmoon <https://github.com/zmoon>`_.
 - Add more readme badges (:pull:`72`).
   By `zmoon <https://github.com/zmoon>`_.
+  
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- Removed support for python 3.6 (:pull:`80`).
+  By `Julius Busecke <https://github.com/jbusecke>`_.
 
 v0.2.0 (2021/4/20)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -59,7 +58,7 @@ install_requires =
     cartopy
 setup_requires=
     setuptools_scm
-python_requires = >=3.6
+python_requires = >=3.7
 ################ Up until here
 
 include_package_data = True


### PR DESCRIPTION
Seems like the CI has been [braking](https://github.com/jbusecke/xmovie/actions/runs/1980811631) for python 3.6 for a while now. 

I am not really willing to spend a lot of time debugging, and will just stop the support for python 3.6 here.