### PR TITLE
Fixes retrieval of chunk sizes for datasets

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -1,6 +1,15 @@
 What's New
 ==========
-v0.3.0 (unreleased)
+v0.3.1
+-------------------
+
+Bug fixes
+~~~~~~~~~~~~~
+- Fixed a bug that prevented parallel frame saving to work with `xarray.Datasets` (:pull:`83`).
+  By `Tomas Chor <https://github.com/tomchor>`.
+
+
+v0.3.0 (2022/3/17)
 -------------------
 
 Documentation

--- a/xmovie/core.py
+++ b/xmovie/core.py
@@ -304,9 +304,7 @@ class Movie:
         if input_check:
             if isinstance(self.data, xr.Dataset):
                 raise ValueError(
-                    "xmovie presets do not yet support the input of xr.Datasets. \
-                In order to use datasets as inputs, set `input_check` to False. \
-                Note that this requires you to manually set colorlimits etc."
+                    "xmovie presets do not yet support the input of xr.Datasets.\nIn order to use datasets as inputs, set `input_check` to False.\nNote that this requires you to manually set colorlimits etc."
                 )
 
             # Set defaults
@@ -414,7 +412,13 @@ class Movie:
             raise ValueError(
                 f"Input data needs to be a dask array to save in parallel. Please chunk the input with single chunks along {framedim}."
             )
-        framedim_chunks = da.chunks[da.dims.index(framedim)]
+
+        if type(da) is xr.DataArray:
+            framedim_chunks = da.chunks[da.dims.index(framedim)]
+        elif type(da) is xr.Dataset:
+            framedim_chunks = da.chunks[framedim]
+        else:
+            raise(TypeError("`da` must be either an xarray.DataArray or xarray.Dataset"))
 
         if not all([chunk == 1 for chunk in framedim_chunks]):
             raise ValueError(

--- a/xmovie/core.py
+++ b/xmovie/core.py
@@ -304,7 +304,7 @@ class Movie:
         if input_check:
             if isinstance(self.data, xr.Dataset):
                 raise ValueError(
-                    "xmovie presets do not yet support the input of xr.Datasets.\nIn order to use datasets as inputs, set `input_check` to False.\nNote that this requires you to manually set colorlimits etc."
+                    "xmovie presets do not yet fully support the input of xr.Datasets.\nIn order to use datasets as inputs, set `input_check` to False.\nNote that this requires you to manually set colorlimits etc."
                 )
 
             # Set defaults


### PR DESCRIPTION
Closes https://github.com/jbusecke/xmovie/issues/82

This fixes the issue for me. Although I did notice some minor issues when using Datasets (like the package giving me this warning even with the keyword `fieldname`: `UserWarning: No fieldname supplied. Defaults to air`), but I think those are best left for future PRs.