### PR TITLE
style(docs): remove tick mark in bash clone command

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,7 +95,7 @@ If you want to install the latest version from GitHub, simply run
 
    .. prompt:: bash
 
-      git clone https://github.com/jbusecke/xmovie.git`
+      git clone https://github.com/jbusecke/xmovie.git
 
    and enter your github password.
 


### PR DESCRIPTION
Removes a small typo where a tick mark is included in the git clone command on the documentation home page.