### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
 
     steps:

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -1,5 +1,13 @@
 What's New
 ==========
+v0.4.0 (unreleased)
+-------------------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- Drop support for Python 3.7 (:pull:`139`).
+  By `Julius Busecke <https://github.com/jbusecke>`.
+
 v0.3.1
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,9 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     # Dont change this one
     License :: OSI Approved :: MIT License
 
@@ -66,7 +66,7 @@ install_requires =
     cartopy
 setup_requires=
     setuptools_scm
-python_requires = >=3.7
+python_requires = >=3.8
 ################ Up until here
 
 include_package_data = True


### PR DESCRIPTION
Just noticed [these](https://github.com/jbusecke/xmovie/actions/runs/4343916242) errors in the CI for python 3.7. It seems related to dask, and I noticed that dask does not support 3.7 since over a [year](https://github.com/dask/dask/pull/8572). So I am removing 3.7 support here.