### PR TITLE
presets._core_plot: allow other interp methods for imshow

### DIFF
--- a/xmovie/presets.py
+++ b/xmovie/presets.py
@@ -45,7 +45,9 @@ def _core_plot(ax, data, plotmethod=None, **kwargs):
     elif plotmethod == "imshow":
         # p = data.plot.imshow(ax=ax, **kwargs)
         # testing interpolation
-        p = data.plot.imshow(ax=ax, interpolation="gaussian", **kwargs)
+        props = dict(interpolation="gaussian")
+        props.update(kwargs)
+        p = data.plot.imshow(ax=ax, **props)
         # print(p.get_interpolation())
     elif plotmethod == "pcolormesh":
         p = data.plot.pcolormesh(ax=ax, **kwargs)


### PR DESCRIPTION
Currently, only "gaussian" interpolation is supported for the imshow plot method. Set it as the default, but also allow users to change the interpolation method. 

The gaussian interpolation method "dilates" missing values. This means that nans grow in coastal regions if the ocean is being plotted. Would be nice to try other approaches that don't grow the missing regions. 