### PR TITLE
use the `Figure` constructor instead of `plt.figure`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,8 +22,7 @@ They have a signature of the type:
 
 .. code-block::
 
-    def plotfunc(da, fig, timestamp, framedim, **kwargs):
-        ...
+    def plotfunc(da, fig, timestamp, framedim, **kwargs): ...
 
 .. autosummary::
    :toctree: api/

--- a/xmovie/core.py
+++ b/xmovie/core.py
@@ -10,6 +10,7 @@ import warnings
 from subprocess import PIPE, STDOUT, Popen
 
 import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 import xarray as xr
 
 from .presets import basic
@@ -71,7 +72,7 @@ def _parse_plot_defaults(da, kwargs):
 
 def _check_plotfunc_output(func, da, framedim="time", **kwargs):
     timestep = 0
-    fig = plt.figure()
+    fig = Figure()
     oargs = func(da, fig, timestep, framedim, **kwargs)
     # I just want the number of output args, delete plot
     plt.close(fig)
@@ -324,7 +325,7 @@ class Movie:
         pp
             Matplotlib primitives returned by the plotting function.
         """
-        fig = plt.figure(figsize=[self.width, self.height])
+        fig = Figure(figsize=[self.width, self.height])
         # create_frame(self.pixelwidth, self.pixelheight, self.dpi)
         # produce dummy output for ax and pp if the plotfunc does not provide them
         if self.plotfunc_n_outargs == 2:

--- a/xmovie/core.py
+++ b/xmovie/core.py
@@ -352,6 +352,8 @@ class Movie:
         with plt.rc_context({"figure.dpi": self.dpi, "figure.figsize": [self.width, self.height]}):
             fig, ax, pp = self.render_single_frame(timestep)
 
+            return fig, ax, pp
+
     def save_frames_serial(self, odir, progress=False):
         """Save movie frames as picture files.
 

--- a/xmovie/core.py
+++ b/xmovie/core.py
@@ -10,8 +10,8 @@ import warnings
 from subprocess import PIPE, STDOUT, Popen
 
 import matplotlib.pyplot as plt
-from matplotlib.figure import Figure
 import xarray as xr
+from matplotlib.figure import Figure
 
 from .presets import basic
 

--- a/xmovie/core.py
+++ b/xmovie/core.py
@@ -352,7 +352,7 @@ class Movie:
         with plt.rc_context({"figure.dpi": self.dpi, "figure.figsize": [self.width, self.height]}):
             fig, ax, pp = self.render_single_frame(timestep)
 
-            return fig, ax, pp
+            return fig
 
     def save_frames_serial(self, odir, progress=False):
         """Save movie frames as picture files.

--- a/xmovie/test/test_core.py
+++ b/xmovie/test/test_core.py
@@ -284,8 +284,7 @@ def test_movie_render_frame(plotfunc, expected_empty):
 def test_movie_preview():
     da = test_dataarray()
     mov = Movie(da)
-    mov.preview(0)
-    fig = plt.gcf()
+    fig, _, _ = mov.preview(0)
     assert mov.dpi == fig.dpi
 
 

--- a/xmovie/test/test_core.py
+++ b/xmovie/test/test_core.py
@@ -284,7 +284,7 @@ def test_movie_render_frame(plotfunc, expected_empty):
 def test_movie_preview():
     da = create_test_dataarray()
     mov = Movie(da)
-    fig, _, _ = mov.preview(0)
+    fig = mov.preview(0)
     assert mov.dpi == fig.dpi
 
 

--- a/xmovie/test/test_core.py
+++ b/xmovie/test/test_core.py
@@ -124,7 +124,7 @@ def test_check_ffmpeg_execute():
         _check_ffmpeg_execute("ls -l?")
 
 
-def test_dataarray():
+def create_test_dataarray():
     """Create a little test dataset"""
     x = np.arange(4)
     y = np.arange(5)
@@ -147,7 +147,7 @@ def test_dataarray():
 def test_write_movie(tmpdir, moviename, remove_frames, framerate, ffmpeg_options):
     frame_pattern = "frame_%05d.png"  # the default
     m = tmpdir.join(moviename)
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da)
     mov.save_frames_serial(tmpdir)
     filenames = [tmpdir.join(frame_pattern % ff) for ff in range(len(da.time))]
@@ -182,7 +182,7 @@ def test_convert_gif(tmpdir, moviename, remove_movie, gif_palette, gifname, gif_
     g = tmpdir.join(gifname)
     gpath = g.strpath
 
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da)
     mov.save_frames_serial(tmpdir)
 
@@ -218,7 +218,7 @@ def test_convert_gif(tmpdir, moviename, remove_movie, gif_palette, gifname, gif_
 @pytest.mark.parametrize("dpi", [50, 200])
 @pytest.mark.parametrize("plotfunc", [None, rotating_globe, dummy_plotfunc])
 def test_Movie(plotfunc, framedim, frame_pattern, dpi, pixelheight, pixelwidth):
-    da = test_dataarray()
+    da = create_test_dataarray()
     kwargs = dict(
         plotfunc=plotfunc,
         framedim=framedim,
@@ -253,7 +253,7 @@ def test_Movie(plotfunc, framedim, frame_pattern, dpi, pixelheight, pixelwidth):
         mov = Movie(da, framedim="wrong")
     # passing dataset without plot_variable (this should error out)
     with pytest.raises(ValueError):
-        ds = xr.Dataset({"some": test_dataarray(), "stuff": test_dataarray()})
+        ds = xr.Dataset({"some": create_test_dataarray(), "stuff": create_test_dataarray()})
         mov = Movie(ds)
 
     # this should work (this way one could pass a totally custom function)
@@ -263,7 +263,7 @@ def test_Movie(plotfunc, framedim, frame_pattern, dpi, pixelheight, pixelwidth):
 
 @pytest.mark.parametrize("plotfunc, expected_empty", [(dummy_plotfunc, True), (basic, False)])
 def test_movie_render_frame(plotfunc, expected_empty):
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da, plotfunc=plotfunc)
 
     if expected_empty:
@@ -282,7 +282,7 @@ def test_movie_render_frame(plotfunc, expected_empty):
 
 
 def test_movie_preview():
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da)
     fig, _, _ = mov.preview(0)
     assert mov.dpi == fig.dpi
@@ -290,7 +290,7 @@ def test_movie_preview():
 
 @pytest.mark.parametrize("frame_pattern", ["frame_%05d.png", "test%05d.png"])
 def test_movie_save_frames(tmpdir, frame_pattern):
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da, frame_pattern=frame_pattern)
     mov.save_frames_serial(tmpdir)
     filenames = [tmpdir.join(frame_pattern % ff) for ff in range(len(da.time))]
@@ -312,7 +312,7 @@ def test_movie_save(tmpdir, parallel, filename, gif_palette, framerate, gif_fram
     print(gif_palette)
     # Need more tests for progress, verbose, overwriting
     path = tmpdir.join(filename)
-    da = test_dataarray()
+    da = create_test_dataarray()
     if parallel:
         da = da.chunk({"time": 1})
     mov = Movie(da)
@@ -344,7 +344,7 @@ def test_movie_save(tmpdir, parallel, filename, gif_palette, framerate, gif_fram
 
 def test_movie_save_parallel_no_dask(tmpdir):
     path = tmpdir.join("movie.mp4")
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da)
     with pytest.raises(ValueError) as excinfo:
         mov.save(
@@ -357,7 +357,7 @@ def test_movie_save_parallel_no_dask(tmpdir):
 
 def test_movie_save_parallel_wrong_chunk(tmpdir):
     path = tmpdir.join("movie.mp4")
-    da = test_dataarray().chunk({"time": 2})
+    da = create_test_dataarray().chunk({"time": 2})
     mov = Movie(da)
     with pytest.raises(ValueError) as excinfo:
         mov.save(
@@ -375,7 +375,7 @@ def test_plotfunc_kwargs(tmpdir):
         if test1 is None:
             raise RuntimeError("test1 cannot be None")
 
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da, plotfunc=plotfunc, test1=3)
     mov.preview(0)
     mov.save_frames_serial(tmpdir)
@@ -391,7 +391,7 @@ def test_plotfunc_kwargs_xfail(tmpdir):
         if test1 is None:
             raise RuntimeError("test1 cannot be None")
 
-    da = test_dataarray()
+    da = create_test_dataarray()
     mov = Movie(da, plotfunc=plotfunc, test1=3)
     mov.preview(0)
     mov.save_frames_serial(tmpdir)


### PR DESCRIPTION
With more than a certain (configurable) amount of figures, `matplotlib` emits this warning:

> More than {max_open_warning} figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.

With lots of figures or big figures, we're thus more likely to run out of memory.

As far as I can tell, we have two options: explicitly close them using `plt.close` as the warning suggests, or create the figure using the constructor. Since it gets rid of global state and is simpler to get right if creating figures in parallel, in this PR I decided to do the latter (but we could certainly also go the other way).

This gets rid of the warning, but we now need to return the figure from `.preview` to be able to display it in a notebook. Otherwise, if we want to keep using `pyplot` for that we need to somehow register the figure with the figure manager in that function, but I couldn't figure out how to do so using the public API.