### PR TITLE
CI maintenance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create conda environment
-        uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7
+        uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7  # v1.8.1
         with:
           cache-downloads: true
           cache-env: true
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create conda environment
-        uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7
+        uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7  # v1.8.1
         with:
           cache-downloads: true
           cache-env: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7  # v1.8.1
         with:
           cache-downloads: true
-          cache-env: true
+          cache-environment: true
           micromamba-version: 'latest'
           environment-file: ci/environment.yml
           create-args: >-
@@ -72,7 +72,7 @@ jobs:
         uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7  # v1.8.1
         with:
           cache-downloads: true
-          cache-env: true
+          cache-environment: true
           micromamba-version: 'latest'
           environment-file: ci/environment-core-deps.yml
           create-args: >-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,13 +32,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create conda environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7
         with:
           cache-downloads: true
           cache-env: true
           micromamba-version: 'latest'
           environment-file: ci/environment.yml
-          extra-specs: |
+          create-args: >-
             python=${{ matrix.python-version }}
       - name: Install xMOVIE
         run: |
@@ -69,13 +69,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create conda environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7
         with:
           cache-downloads: true
           cache-env: true
           micromamba-version: 'latest'
           environment-file: ci/environment-core-deps.yml
-          extra-specs: |
+          create-args: >-
             python=3.10
       - name: Install xMOVIE
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
           micromamba-version: 'latest'
           environment-file: ci/environment-core-deps.yml
           create-args: >-
-            python=3.10
+            python=3.11
       - name: Install xMOVIE
         run: |
           python -m pip install -e . --no-deps

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,8 +22,7 @@ They have a signature of the type:
 
 .. code-block::
 
-    def plotfunc(da, fig, timestamp, framedim, **kwargs):
-        ...
+    def plotfunc(da, fig, timestamp, framedim, **kwargs): ...
 
 .. autosummary::
    :toctree: api/


### PR DESCRIPTION
Looks like CI has not been touched in a while, it was still using the deprecated / unmaintained `provision-with-micromamba` action, together with old(er) versions of `python`.